### PR TITLE
feat: Configure Geist Sans as default font

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,11 @@ module.exports = {
     "./Services/**/*.{js,jsx,ts,tsx}",
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Geist Sans', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
Updated the Tailwind CSS configuration to use Geist Sans as the default sans-serif font family. This ensures a consistent and modern typography across the application.